### PR TITLE
🐛Make integration tests multiplatform

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,6 +36,10 @@ If not set, `vaultlib` will fallback to safe default values.
 
 > `vautlib` will automatically use the http_proxy environment variable to connect to Vault
 
+## Tests
+
+To test this library, run `go1.11.13 test -vaultVersion 1.4.1` in the root of the repo.
+
 ## Getting Started
 
 > For a simple, working example, check the sample folder.

--- a/integration_test.go
+++ b/integration_test.go
@@ -13,11 +13,6 @@ var vaultRoleID, vaultSecretID, noKVRoleID, noKVSecretID string
 
 var vaultVersion string
 
-var _ = func() bool {
-	testing.Init()
-	return true
-}()
-
 func init() {
 	flag.StringVar(&vaultVersion, "vaultVersion", "1.0.1", "provide vault version to be tested against")
 	flag.Parse()

--- a/integration_test.go
+++ b/integration_test.go
@@ -13,6 +13,11 @@ var vaultRoleID, vaultSecretID, noKVRoleID, noKVSecretID string
 
 var vaultVersion string
 
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 func init() {
 	flag.StringVar(&vaultVersion, "vaultVersion", "1.0.1", "provide vault version to be tested against")
 	flag.Parse()

--- a/integration_test.go
+++ b/integration_test.go
@@ -14,7 +14,7 @@ var vaultRoleID, vaultSecretID, noKVRoleID, noKVSecretID string
 var vaultVersion string
 
 func init() {
-	flag.StringVar(&vaultVersion, "vaultVersion", "1.0.1", "provide vault version to be tested against")
+	flag.StringVar(&vaultVersion, "vaultVersion", "1.4.1", "provide vault version to be tested against")
 	flag.Parse()
 }
 func TestMain(m *testing.M) {

--- a/test-files/initVaultDev.sh
+++ b/test-files/initVaultDev.sh
@@ -3,11 +3,23 @@ export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=my-dev-root-vault-token
 export VAULT_VERSION=${1:-1.0.1}
 
+case "$(uname -s)" in
+  Darwin*)
+    os="darwin_amd64"
+    ;;
+  MINGW64*)
+    os="windows_amd64"
+    ;;
+  *)
+    os="linux_amd64"
+    ;;
+esac
+
 CURRENT_VAULT=`./vault version | cut -d'v' -f2 | cut -d' ' -f1`
 if [ "$CURRENT_VAULT" != "$VAULT_VERSION" ]; then
     rm -rf ./vault
-    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
-    unzip vault_${VAULT_VERSION}_linux_amd64.zip
+    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${os}.zip
+    unzip vault_${VAULT_VERSION}_${os}.zip
 fi
 
 ./vault server -dev -dev-root-token-id ${VAULT_TOKEN}  > /tmp/vaultdev.log &

--- a/test-files/initVaultDev.sh
+++ b/test-files/initVaultDev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=my-dev-root-vault-token
-export VAULT_VERSION=${1:-1.0.1}
+export VAULT_VERSION=${1:-1.4.1}
 
 case "$(uname -s)" in
   Darwin*)

--- a/test-files/initVaultDev.sh
+++ b/test-files/initVaultDev.sh
@@ -5,21 +5,21 @@ export VAULT_VERSION=${1:-1.0.1}
 
 case "$(uname -s)" in
   Darwin*)
-    os="darwin_amd64"
+    OS="darwin_amd64"
     ;;
   MINGW64*)
-    os="windows_amd64"
+    OS="windows_amd64"
     ;;
   *)
-    os="linux_amd64"
+    OS="linux_amd64"
     ;;
 esac
 
 CURRENT_VAULT=`./vault version | cut -d'v' -f2 | cut -d' ' -f1`
 if [ "$CURRENT_VAULT" != "$VAULT_VERSION" ]; then
     rm -rf ./vault
-    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${os}.zip
-    unzip vault_${VAULT_VERSION}_${os}.zip
+    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${OS}.zip
+    unzip vault_${VAULT_VERSION}_${OS}.zip
 fi
 
 ./vault server -dev -dev-root-token-id ${VAULT_TOKEN}  > /tmp/vaultdev.log &


### PR DESCRIPTION
## Context and Description of Changes Proposed

Tests on the base vaultlib library fail with:
```error getting role id fork/exec ./vault: exec format error []```

This PR comprises Atha's solution to the problem (commit "Atha's fix - get correct vault for localhost OS").  Reviewers should run ```go1.11.13 test``` in ```/vaultlib``` to confirm.

## Draft Commit Message Body

Update vaultlib to pass tests across operating systems.

PR #1
close [ch1055]