### PR TITLE
🐛 Update handling of flags for Go 1.13+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ services:
 before_install:
   - go get github.com/mattn/goveralls
 script:
-  - goveralls -v -service=travis-ci
+  - goveralls -debug -v -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ services:
 before_install:
   - go get github.com/mattn/goveralls
 script:
-  - goveralls -debug -v -service=travis-ci
+  - go test -v -covermode=count -coverprofile=coverage.out
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ branches:
   - master
 language: go
 go:
-    - 1.11.4
+    - 1.11.13
+    - 1.12.17
+    - 1.13.10
+    - 1.14.2
 install: true
 sudo: required
 services:

--- a/integration_test.go
+++ b/integration_test.go
@@ -13,15 +13,18 @@ var vaultRoleID, vaultSecretID, noKVRoleID, noKVSecretID string
 
 var vaultVersion string
 
-func init() {
-	flag.StringVar(&vaultVersion, "vaultVersion", "1.4.1", "provide vault version to be tested against")
-	flag.Parse()
-}
 func TestMain(m *testing.M) {
-
+	flag.StringVar(
+		&vaultVersion,
+		"vaultVersion",
+		"1.4.1",
+		"provide vault version to be tested against",
+	)
+	flag.Parse()
 	fmt.Println("Testing with Vault version", vaultVersion)
 	fmt.Println("TestMain: Preparing Vault server")
 	prepareVault()
+	fmt.Println("TestMain: Vault Prepared; Running Tests")
 	ret := m.Run()
 	os.Exit(ret)
 }


### PR DESCRIPTION
## Draft Commit Message
```
Go 1.13 introduces a Testing.Init function for handling test flags.

https://tip.golang.org/doc/go1.13#testing

This has the unfortunate consequence of panicking if flags are parsed
before testing.Init is called (for instance, in init). We therefore
update the code to parse flags in the Testing Main override such that
tests may be run in Go 1.11-1.14.

Related:
https://github.com/golang/go/issues/31859

PR #3
[close ch1056]
```