### PR TITLE
❗️ Adjust module to use True Tickets repository

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/TrueTickets/vaultlib.svg?branch=master)](https://travis-ci.org/TrueTickets/vaultlib)
 [![Coverage Status](https://coveralls.io/repos/github/TrueTickets/vaultlib/badge.svg?branch=master)](https://coveralls.io/github/TrueTickets/vaultlib?branch=master) [![GoDoc](https://godoc.org/github.com/TrueTickets/vaultlib?status.svg)](https://godoc.org/github.com/TrueTickets/vaultlib) [![Go Report Card](https://goreportcard.com/badge/github.com/TrueTickets/vaultlib)](https://goreportcard.com/report/github.com/TrueTickets/vaultlib)
 
+This work forks Michael Champagne's vaultlib at https://github.com/mch1307/vaultlib
+
 Lightweight, simple Go library for Vault secret reading (http API).
 
 Connect to Vault through app role or token.

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # vaultlib
 
-[![Build Status](https://travis-ci.org/mch1307/vaultlib.svg?branch=master)](https://travis-ci.org/mch1307/vaultlib)
-[![Coverage Status](https://coveralls.io/repos/github/mch1307/vaultlib/badge.svg?branch=master)](https://coveralls.io/github/mch1307/vaultlib?branch=master) [![GoDoc](https://godoc.org/github.com/mch1307/vaultlib?status.svg)](https://godoc.org/github.com/mch1307/vaultlib) [![Go Report Card](https://goreportcard.com/badge/github.com/mch1307/vaultlib)](https://goreportcard.com/report/github.com/mch1307/vaultlib)
+[![Build Status](https://travis-ci.org/TrueTickets/vaultlib.svg?branch=master)](https://travis-ci.org/TrueTickets/vaultlib)
+[![Coverage Status](https://coveralls.io/repos/github/TrueTickets/vaultlib/badge.svg?branch=master)](https://coveralls.io/github/TrueTickets/vaultlib?branch=master) [![GoDoc](https://godoc.org/github.com/TrueTickets/vaultlib?status.svg)](https://godoc.org/github.com/TrueTickets/vaultlib) [![Go Report Card](https://goreportcard.com/badge/github.com/TrueTickets/vaultlib)](https://goreportcard.com/report/github.com/TrueTickets/vaultlib)
 
 Lightweight, simple Go library for Vault secret reading (http API).
 
@@ -52,7 +52,7 @@ import (
     "log"
     "os"
 
-    vault "github.com/mch1307/vaultlib"
+    vault "github.com/TrueTickets/vaultlib"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
-module github.com/mch1307/vaultlib
+module github.com/TrueTickets/vaultlib
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
+	github.com/TrueTickets/vaultlib v0.5.0
 	github.com/pkg/errors v0.8.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/TrueTickets/vaultlib
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/TrueTickets/vaultlib v0.5.0
 	github.com/pkg/errors v0.8.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/mch1307/vaultlib v0.5.0 h1:+tI8YCG033aVI+kAKwo0fwrUylFs+wO6DB7DM5qXJzU=
-github.com/mch1307/vaultlib v0.5.0/go.mod h1:phFbO1oIDL1xTqUrNXbrAG0VdcYEKP8TNa9FJd7hFic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/mch1307/vaultlib v0.5.0 h1:+tI8YCG033aVI+kAKwo0fwrUylFs+wO6DB7DM5qXJzU=
+github.com/mch1307/vaultlib v0.5.0/go.mod h1:phFbO1oIDL1xTqUrNXbrAG0VdcYEKP8TNa9FJd7hFic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Context and Description of Changes Proposed

This work replaces references to the original mch1307 parent library in several places with TrueTickets, most importantly in go.mod, where the reference to the original is breaking.

## Draft Commit Message Body
Update go.mod, etc. to refer to the TrueTickets repository rather than
the parent mch1307.

PR #4