### PR TITLE
🔨 Add Shutdown method to vault client

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,7 +59,7 @@ type VaultTokenInfo struct {
 //
 // If you are using the client and then disposing it, make sure you call
 // defer client.Shutdown() once you are done with it. Failing to do so will
-// result in an infinite gorutine running in the background.
+// result in an infinite goroutine running in the background.
 func NewClient(c *Config) (*Client, error) {
 	var caPool *x509.CertPool
 	// If no config provided, use a new one based on default values and env vars

--- a/client.go
+++ b/client.go
@@ -58,7 +58,7 @@ type VaultTokenInfo struct {
 // NewClient returns a new client based on the provided config.
 //
 // If you are using the client and then disposing it, make sure you call
-// `defer client.Shutdown()` once you are done with it. Failing to do so will
+// defer client.Shutdown() once you are done with it. Failing to do so will
 // result in an infinite gorutine running in the background.
 func NewClient(c *Config) (*Client, error) {
 	var caPool *x509.CertPool

--- a/client.go
+++ b/client.go
@@ -72,10 +72,7 @@ func NewClient(c *Config) (*Client, error) {
 	cli.appRoleCredentials = new(AppRoleCredentials)
 	cli.appRoleCredentials.RoleID = c.AppRoleCredentials.RoleID
 	cli.appRoleCredentials.SecretID = c.AppRoleCredentials.SecretID
-
-	// We explicitly set cli.done to nil to mean "channel is not used";
-	// the channel will be used only if renewToken loop is started.
-	cli.done = nil
+	cli.done = make(chan bool, 1)
 
 	u, err := url.Parse(c.Address)
 	if err != nil {
@@ -120,9 +117,6 @@ func NewClient(c *Config) (*Client, error) {
 			return &cli, err
 		}
 		if cli.token.Renewable {
-			// Make sure the channel is created only when it's necessary
-			// (when token is renewable and there are no errors).
-			cli.done = make(chan bool)
 			go cli.renewToken()
 		}
 

--- a/client.go
+++ b/client.go
@@ -58,8 +58,8 @@ type VaultTokenInfo struct {
 // NewClient returns a new client based on the provided config.
 //
 // If you are using the client and then disposing it, make sure you call
-// defer client.Shutdown once you are done with it. Failing to do so will result
-// in an infinite gorutine running in the background.
+// `defer client.Shutdown()` once you are done with it. Failing to do so will
+// result in an infinite gorutine running in the background.
 func NewClient(c *Config) (*Client, error) {
 	var caPool *x509.CertPool
 	// If no config provided, use a new one based on default values and env vars
@@ -73,8 +73,8 @@ func NewClient(c *Config) (*Client, error) {
 	cli.appRoleCredentials.RoleID = c.AppRoleCredentials.RoleID
 	cli.appRoleCredentials.SecretID = c.AppRoleCredentials.SecretID
 
-	// explicitly setting to nil to mean "channel is not used"
-	// channel will be used only if renewToken loop is started
+	// We explicitly set cli.done to nil to mean "channel is not used";
+	// the channel will be used only if renewToken loop is started.
 	cli.done = nil
 
 	u, err := url.Parse(c.Address)
@@ -120,8 +120,8 @@ func NewClient(c *Config) (*Client, error) {
 			return &cli, err
 		}
 		if cli.token.Renewable {
-			// make sure the channel is created only when it's necessary
-			// (when token is renewable and there are no errors)
+			// Make sure the channel is created only when it's necessary
+			// (when token is renewable and there are no errors).
 			cli.done = make(chan bool)
 			go cli.renewToken()
 		}
@@ -180,7 +180,7 @@ func (c *Client) withLockContext(fn func()) {
 }
 
 // Shutdown stops the infinite renewToken loop and cleans up any associated
-// resources for the client. You can call defer client.Shutdown() safely even
+// resources for the client. You can call `defer client.Shutdown()` safely even
 // if no renewToken loop is running.
 func (c *Client) Shutdown() {
 	if c.done != nil {

--- a/client.go
+++ b/client.go
@@ -180,7 +180,7 @@ func (c *Client) withLockContext(fn func()) {
 }
 
 // Shutdown stops the infinite renewToken loop and cleans up any associated
-// resources for the client. You can call `defer client.Shutdown()` safely even
+// resources for the client. You can call defer client.Shutdown() safely even
 // if no renewToken loop is running.
 func (c *Client) Shutdown() {
 	if c.done != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -14,6 +14,8 @@ func TestNewClient(t *testing.T) {
 	defaultCfg.AppRoleCredentials.RoleID = vaultRoleID
 	defaultCfg.AppRoleCredentials.SecretID = vaultSecretID
 	vc, _ := NewClient(defaultCfg)
+	defer vc.Shutdown()
+
 	// create new config with a vault token
 	os.Setenv("VAULT_TOKEN", "my-renewable-token")
 	cfg := NewConfig()
@@ -71,6 +73,7 @@ func Example() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer vaultCli.Shutdown()
 
 	// Get the Vault KV secret from kv_v1/path/my-secret
 	kvV1, err := vaultCli.GetSecret("kv_v1/path/my-secret")
@@ -92,7 +95,7 @@ func Example() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(fmt.Sprintf("%v", jsonSecret.JSONSecret))
+	fmt.Printf("%v\n", jsonSecret.JSONSecret)
 }
 
 func ExampleNewClient() {
@@ -101,6 +104,8 @@ func ExampleNewClient() {
 	if err != nil {
 		fmt.Println(err)
 	}
+	defer myVaultClient.Shutdown()
+
 	fmt.Println(myVaultClient.address)
 }
 
@@ -110,6 +115,8 @@ func ExampleClient_IsAuthenticated() {
 	if err != nil {
 		fmt.Println(err)
 	}
+	defer myVaultClient.Shutdown()
+
 	if myVaultClient.IsAuthenticated() {
 		fmt.Println("myVaultClient's connection is ok")
 	}
@@ -121,6 +128,8 @@ func TestClient_IsAuthenticated(t *testing.T) {
 	authCli, _ := NewClient(conf)
 	conf.Token = "bad-token"
 	badCli, _ := NewClient(conf)
+	defer badCli.Shutdown()
+
 	tests := []struct {
 		name string
 		cli  *Client
@@ -143,6 +152,8 @@ func TestClient_GetTokenInfo(t *testing.T) {
 	defaultCfg := NewConfig()
 	defaultCfg.Token = "my-dev-root-vault-token"
 	client, _ := NewClient(defaultCfg)
+	defer client.Shutdown()
+
 	tokenOK := new(VaultTokenInfo)
 	tokenOK.ID = defaultCfg.Token
 	tests := []struct {
@@ -166,6 +177,8 @@ func TestClient_GetStatus(t *testing.T) {
 	defaultCfg := NewConfig()
 	defaultCfg.Token = "my-dev-root-vault-token"
 	client, _ := NewClient(defaultCfg)
+	defer client.Shutdown()
+
 	tests := []struct {
 		name string
 		cli  *Client

--- a/client_test.go
+++ b/client_test.go
@@ -126,6 +126,7 @@ func TestClient_IsAuthenticated(t *testing.T) {
 	conf := NewConfig()
 	conf.Token = "my-dev-root-vault-token"
 	authCli, _ := NewClient(conf)
+	defer authCli.Shutdown()
 	conf.Token = "bad-token"
 	badCli, _ := NewClient(conf)
 	defer badCli.Shutdown()

--- a/client_test.go
+++ b/client_test.go
@@ -54,6 +54,10 @@ func TestNewClient(t *testing.T) {
 				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if got != nil {
+				defer got.Shutdown()
+			}
+
 			if !tt.wantErr && !(got.status == tt.want.status) {
 				t.Errorf("NewClient() = %v, want %v", got, tt.want)
 			}
@@ -127,6 +131,7 @@ func TestClient_IsAuthenticated(t *testing.T) {
 	conf.Token = "my-dev-root-vault-token"
 	authCli, _ := NewClient(conf)
 	defer authCli.Shutdown()
+
 	conf.Token = "bad-token"
 	badCli, _ := NewClient(conf)
 	defer badCli.Shutdown()

--- a/request_test.go
+++ b/request_test.go
@@ -13,6 +13,8 @@ import (
 
 func Test_newRequest(t *testing.T) {
 	cli, _ := NewClient(nil)
+	defer cli.Shutdown()
+
 	testURL, _ := url.Parse("http://localhost:8200")
 	emptyReq := new(request)
 	type args struct {
@@ -83,6 +85,8 @@ func Test_request_execute(t *testing.T) {
 func Test_request_setJSONBody(t *testing.T) {
 	var cred AppRoleCredentials
 	cli, _ := NewClient(nil)
+	defer cli.Shutdown()
+
 	cred.RoleID = "aa"
 	cred.SecretID = "bb"
 	htCli := new(http.Client)
@@ -131,6 +135,8 @@ func TestClient_RawRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get vault cli %v", err)
 	}
+	defer vc.Shutdown()
+
 	vc.token.ID = "my-dev-root-vault-token"
 	ch := make(chan int)
 	type args struct {

--- a/vault_test.go
+++ b/vault_test.go
@@ -48,6 +48,7 @@ func TestVaultClient_getKVInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, _ := NewClient(tt.fields.Config)
+			defer c.Shutdown()
 			gotVersion, gotName, err := c.getKVInfo(tt.args.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.getKVInfo() error = %v, wantErr %v", err, tt.wantErr)
@@ -72,9 +73,11 @@ func TestVaultClient_GetSecret(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get vault cli %v", err)
 	}
+	defer vc.Shutdown()
 
 	conf.Address = "https://localhost:8200"
 	badCli, _ := NewClient(conf)
+	defer badCli.Shutdown()
 
 	conf.Address = "http://localhost:8200"
 	conf.AppRoleCredentials.RoleID = noKVRoleID


### PR DESCRIPTION
## Context and Description of Changes Proposed

This PR introduces a Shutdown method to call once you are done using the vault client.
As described in https://app.clubhouse.io/truetickets/story/3815/remove-memory-leak-from-vaultlib-to-allow-deploy-of-ambasador-aes-1-12-1 the `renewToken` goroutine was running forever, so creating multiple vaultclients was leaking memory and cpu.

Users of this lib can now `defer client.Shutdown()` to end the goroutine, as seen in tests.

I'm also giving the Assignee the responsibility to tag and release the library after merged.

## Draft Commit Message Body

```
PR #7
close [ch3815]
```
